### PR TITLE
I tried to fix some problems I encountered when I used it

### DIFF
--- a/bitmapfonts.py
+++ b/bitmapfonts.py
@@ -101,7 +101,10 @@ def get_unicode(word) -> bytes:
     Returns:
 
     """
-    return struct.pack(">H", ord(word))
+    o = ord(word)
+    if o > 65535:
+        o = 65311  # 65311 = ord("？") or 32 = ord(" ")
+    return struct.pack(">H", o)
 
 
 def run(font_file, font_size=16, offset=(0, 0), text_file=None, text=None, bitmap_fonts_name=None,

--- a/main.py
+++ b/main.py
@@ -15,7 +15,8 @@ def set_font_file():
     """
     global font_file
     font_file = askopenfilename(title='选择字体文件',
-                                filetypes=[('TrueType Font', '*.ttf'), ('TrueType Font', '*.ttc'), ('All Files', '*')],
+                                filetypes=[('Font File', '*.ttf'), ('Font File', '*.ttc'), ('Font File', '*.otf'),
+                                           ('All Files', '*')],
                                 initialdir="./")
     font_file_show.set(font_file)
     get_image()


### PR DESCRIPTION
1. File "bitmapfonts.py", line 104, in get_unicode
struct.error: 'H' format requires 0 <= number <= 65535.

2. otf font files are not supported, But when I choose the otf file, it works fine.